### PR TITLE
Bugfix: add timeout to resolveOnEvent

### DIFF
--- a/src/Chat/utils/commands.ts
+++ b/src/Chat/utils/commands.ts
@@ -2,10 +2,9 @@ import camelCase from 'lodash/camelCase'
 import toUpper from 'lodash/toUpper'
 
 import { ChatCommands, KnownNoticeMessageIds, Commands } from '../../twitch'
+import { COMMAND_TIMEOUT } from '../constants'
 
 import * as utils from '../../utils'
-
-const EVENT_TIMEOUT_LIMIT = 10000
 
 export const factory = (chatInstance: any) => {
   Object.entries(ChatCommands).forEach(([key, command]) => {
@@ -178,7 +177,7 @@ export const resolvers = (chatInstance: any) => (
         utils.resolveOnEvent(
           chatInstance,
           `${notices.TIMEOUT_SUCCESS}/${channel}`,
-          EVENT_TIMEOUT_LIMIT,
+          COMMAND_TIMEOUT,
         ),
       ]
 

--- a/src/Chat/utils/commands.ts
+++ b/src/Chat/utils/commands.ts
@@ -5,6 +5,8 @@ import { ChatCommands, KnownNoticeMessageIds, Commands } from '../../twitch'
 
 import * as utils from '../../utils'
 
+const EVENT_TIMEOUT_LIMIT = 10000
+
 export const factory = (chatInstance: any) => {
   Object.entries(ChatCommands).forEach(([key, command]) => {
     chatInstance[camelCase(key)] = (channel: string, ...args: string[]) =>
@@ -176,6 +178,7 @@ export const resolvers = (chatInstance: any) => (
         utils.resolveOnEvent(
           chatInstance,
           `${notices.TIMEOUT_SUCCESS}/${channel}`,
+          EVENT_TIMEOUT_LIMIT,
         ),
       ]
 

--- a/src/utils/__tests__/index.test.ts
+++ b/src/utils/__tests__/index.test.ts
@@ -1,6 +1,5 @@
 import * as utils from '../'
 import EventEmitter from 'eventemitter3'
-import { GlobalFunction } from 'lodash/common/lang'
 
 describe('utils', () => {
   describe('resolveAfter', () => {

--- a/src/utils/__tests__/index.test.ts
+++ b/src/utils/__tests__/index.test.ts
@@ -1,4 +1,6 @@
 import * as utils from '../'
+import EventEmitter from 'eventemitter3'
+import { GlobalFunction } from 'lodash/common/lang'
 
 describe('utils', () => {
   describe('resolveAfter', () => {
@@ -6,6 +8,63 @@ describe('utils', () => {
       jest.useFakeTimers()
       utils.resolveAfter(100).then(() => done())
       jest.runOnlyPendingTimers()
+    })
+  })
+
+  describe('resolveOnEvent', () => {
+    const emitter = new EventEmitter()
+
+    beforeEach(jest.useFakeTimers)
+    afterEach(jest.restoreAllMocks)
+    afterEach(() => emitter.removeAllListeners())
+
+    it('should resolve promise on event', done => {
+      utils
+        .resolveOnEvent(emitter, 'event')
+        .then(result => expect(result).toEqual('value'))
+        .then(done)
+
+      emitter.emit('event', 'value')
+    })
+
+    it('should never reject if no timeout is passed', () => {
+      const resolveSpy = jest.fn()
+      const rejectSpy = jest.fn()
+
+      jest
+        .spyOn(global, 'Promise')
+        .mockImplementation(callback => callback(resolveSpy, rejectSpy))
+
+      utils.resolveOnEvent(emitter, 'event')
+      jest.runOnlyPendingTimers()
+
+      expect(resolveSpy).toBeCalledTimes(0)
+      expect(rejectSpy).toBeCalledTimes(0)
+    })
+
+    it('should reject with timemout', done => {
+      utils.resolveOnEvent(emitter, 'event', 10000).catch(error => {
+        expect(error).toEqual(new Error('no event emitted, timed out'))
+        done()
+      })
+
+      jest.runOnlyPendingTimers()
+    })
+
+    it('should only expire instance of timed out listener', async () => {
+      expect.assertions(2)
+
+      const firstPromise = utils.resolveOnEvent(emitter, 'event')
+      const secondPromise = utils.resolveOnEvent(emitter, 'event', 10000)
+
+      jest.advanceTimersByTime(10000)
+
+      emitter.emit('event', 'value')
+
+      await secondPromise.catch(error => expect(error).toBeTruthy())
+
+      const result = await firstPromise
+      expect(result).toEqual('value')
     })
   })
 

--- a/src/utils/__tests__/index.test.ts
+++ b/src/utils/__tests__/index.test.ts
@@ -11,13 +11,13 @@ describe('utils', () => {
   })
 
   describe('resolveOnEvent', () => {
-    const emitter = new EventEmitter()
-
     beforeEach(jest.useFakeTimers)
+
     afterEach(jest.restoreAllMocks)
-    afterEach(() => emitter.removeAllListeners())
 
     it('should resolve promise on event', done => {
+      const emitter = new EventEmitter()
+
       utils
         .resolveOnEvent(emitter, 'event')
         .then(result => expect(result).toEqual('value'))
@@ -27,6 +27,7 @@ describe('utils', () => {
     })
 
     it('should never reject if no timeout is passed', () => {
+      const emitter = new EventEmitter()
       const resolveSpy = jest.fn()
       const rejectSpy = jest.fn()
 
@@ -42,6 +43,8 @@ describe('utils', () => {
     })
 
     it('should reject with timemout', done => {
+      const emitter = new EventEmitter()
+
       utils.resolveOnEvent(emitter, 'event', 10000).catch(error => {
         expect(error).toEqual(new Error('no event emitted, timed out'))
         done()
@@ -52,6 +55,7 @@ describe('utils', () => {
 
     it('should only expire instance of timed out listener', async () => {
       expect.assertions(2)
+      const emitter = new EventEmitter()
 
       const firstPromise = utils.resolveOnEvent(emitter, 'event')
       const secondPromise = utils.resolveOnEvent(emitter, 'event', 10000)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,7 +6,17 @@ export const resolveAfter = (ms: number) =>
 export const resolveOnEvent = <T>(
   emitter: EventEmitter<any>,
   eventName: string,
-): Promise<T> => new Promise(resolve => emitter.once(eventName, resolve))
+  timeout = 0,
+): Promise<T> =>
+  new Promise((resolve, reject) => {
+    emitter.once(eventName, resolve)
+
+    if (timeout)
+      setTimeout(() => {
+        emitter.removeListener(eventName, resolve)
+        reject(new Error('no event emitted, timed out'))
+      }, timeout)
+  })
 
 export const resolveInSequence = (tasks: (() => Promise<any>)[]) =>
   tasks.reduce((p, task) => p.then(task), Promise.resolve())


### PR DESCRIPTION
## Proposed changes

This implementation is a fix to some eternal promises problem (promises that never resolve). It adds a timeout to resolveOnEvent, so events never called will cause a rejection on this promise.

This approach keeps the same behavior to existing implementations, but adds a timeout value to new ones, so after some other refactors could help fix those unresolved promises appearing in tests.

## Types of changes

<!--
  What types of changes does your code introduce to TwitchJS? _Put an `x` in the
  boxes that apply and remove those that do not apply_
-->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] Chore (change that does not fix an issue or add functionality, but
      improves TwitchJS in some other way)

## Checklist

<!--
  _Put an `x` in the boxes that apply. You can also fill these out after creating
  the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
  help! This is simply a reminder of what we are going to look for before merging
  your code._
-->

- [x] I have read the
      [CONTRIBUTING.md](https://github.com/twitch-js/twitch-js/blob/master/CONTRIBUTING.md)
      doc
- [] My PR is named according to
      [CONTRIBUTING.md](https://github.com/twitch-js/twitch-js/blob/master/CONTRIBUTING.md)
      doc
- [x] End-to-end tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I suggest 2 possible approaches to implement it on other functions:
- [ ] keep this as is and go add a timeout argument on every call of resolveOnEvent. Then, after all implemented, removing the argument and use it inside resolveOnEvent as a default behavior.
- [ ] use it inside resolveOnEvent as a default behavior, causing possible diferent behaviors