### PR TITLE
Chore: added TSDoc doc on `Api.onAuthenticationFailure` optional method

### DIFF
--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -7,6 +7,13 @@ export type ApiOptions = {
   token: string
   clientId?: string
   log?: LoggerOptions
+
+  /**
+   * Called when a 401: Unauthorized response is returned.
+   * Returns a `Promise` that must resolve with the refreshed token.
+   * Upon resolution, the original request (with original parameters) is repeated using the provided token.
+   * @see https://github.com/twitch-js/twitch-js#refreshing-tokens
+   */
   onAuthenticationFailure?: () => Promise<string>
 }
 


### PR DESCRIPTION
## Proposed changes

Added TSDoc doc directly on the `ApiOptions.onAuthenticationFailure` method. Documentation on this project is amazing, it speeds up development by allowing to not go back and fourth from docs and IDE because it is readily provided TSDoc's. I felt like it was missing on the aforementioned method and thought I would add it.

## Types of changes

- [ x ] Chore

## Checklist

- [ x ] I have read the [CONTRIBUTING.md] doc
- [ x ] My PR is named according to [CONTRIBUTING.md] doc
- [ ] End-to-end tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

No comments.

<!--
  Do not make any modifications below this comment.
-->

[contributing.md]:
  https://github.com/twitch-js/twitch-js/blob/master/CONTRIBUTING.md
